### PR TITLE
fix: convert netmode field to mode field for compatibility

### DIFF
--- a/custom_components/miwifi/luci.py
+++ b/custom_components/miwifi/luci.py
@@ -449,7 +449,11 @@ class LuciClient:
         except:
             _LOGGER.info("Primary endpoint failed load qnetwork/get_netmode")
             try:
-                return await self.netmode()
+                response = await self.netmode()
+                # Convert netmode field to mode field for compatibility
+                if isinstance(response, dict) and "netmode" in response and "mode" not in response:
+                    response["mode"] = response["netmode"]
+                return response
             except Exception as e:
                 _LOGGER.error("Fallback endpoint also failed: %s", e)
                 return {"mode": 0}


### PR DESCRIPTION
On rd18, since `xqnetwork/get_netmode` returns `{"netmode":2,"code":0}`, `netmode` field need to be converted to `mode`.