### PR TITLE
Fix deprecated ScannerEntity import path (#309)

### DIFF
--- a/custom_components/miwifi/device_tracker.py
+++ b/custom_components/miwifi/device_tracker.py
@@ -7,8 +7,7 @@ import time
 from functools import cached_property
 from typing import Any, Final
 
-from homeassistant.components.device_tracker import ENTITY_ID_FORMAT
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ENTITY_ID_FORMAT, ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er


### PR DESCRIPTION
## What changed

`ScannerEntity` is now imported from `homeassistant.components.device_tracker` instead of the deprecated `homeassistant.components.device_tracker.config_entry` alias.

```diff
-from homeassistant.components.device_tracker import ENTITY_ID_FORMAT
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ENTITY_ID_FORMAT, ScannerEntity
```

## Why

Home Assistant moved `ScannerEntity` to the top-level `device_tracker` package. The old `config_entry` path is now a deprecated alias that logs a warning and is scheduled for removal in **HA Core 2027.6**.

Closes #309.

## Reviewer notes

- The class is only referenced via the import; usage (`class MiWifiDeviceTracker(ScannerEntity, CoordinatorEntity)`) is unchanged.
- Compatibility verified: minimum supported HA is **2025.8.0** (`hacs.json`), and `device_tracker/__init__.py` already re-exports `ScannerEntity` in that release, so the new import resolves on every supported version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)